### PR TITLE
Fix link typo in usage.md

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -15,7 +15,7 @@ Using the default values, the example below will create a portrait-oriented, A4-
 
 You can easily customize the generated map by changing the tile server, size, orientation, etc. For an exhaustive list of all available options, please see the [API Reference](https://papermap.readthedocs.io/en/stable/api.html#papermap.papermap.PaperMap).
 
-For example, the example below will create a landscape-oriented, A3-sized [map of Madrid](_static/Madrid.pdf) using the Stamen Terrain](https://stamen.com/say-hello-to-global-stamen-terrain-maps-c195b3bb71e0/) tile server, with a UTM grid overlay, at scale 1:50000:
+For example, the example below will create a landscape-oriented, A3-sized [map of Madrid](_static/Madrid.pdf) using the [Stamen Terrain](https://stamen.com/say-hello-to-global-stamen-terrain-maps-c195b3bb71e0/) tile server, with a UTM grid overlay, at scale 1:50000:
 
 ```python
 >>> from papermap import PaperMap


### PR DESCRIPTION
Browsing the docs, saw this link was missing a bracket