### PR TITLE
:memo: Update CLAUDE.md with current project state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,10 @@
 
 **PaperMap** is a Python package and CLI tool for creating ready-to-print paper maps from various tile servers (OpenStreetMap, Google Maps, ESRI, etc.). The project generates PDF maps at customizable scales, sizes (A0-A7, letter, legal), and orientations with optional UTM grid overlays.
 
-- **Current Version:** 0.3.0
+- **Current Version:** 2026.1.0 (CalVer: YYYY.N.N)
 - **License:** GNU General Public License v3+
-- **Python Support:** 3.10+
-- **Package Manager:** flit
+- **Python Support:** 3.10, 3.11, 3.12, 3.13, 3.14
+- **Package Manager:** uv
 - **Documentation:** https://papermap.readthedocs.io/
 
 ## Repository Structure
@@ -15,7 +15,7 @@
 ```
 papermap/
 ├── src/papermap/          # Main source code
-│   ├── __init__.py        # Package initialization, version
+│   ├── __init__.py        # Package initialization, exports PaperMap
 │   ├── __main__.py        # Entry point for CLI
 │   ├── cli.py             # Click-based CLI implementation
 │   ├── papermap.py        # Core PaperMap class (main logic)
@@ -26,63 +26,128 @@ papermap/
 │   ├── utils.py           # Utility functions (coordinate conversions, etc.)
 │   ├── typing.py          # Type aliases
 │   └── py.typed           # PEP 561 marker for type information
+├── tests/                 # Test suite
+│   ├── __init__.py
+│   ├── conftest.py        # Shared fixtures
+│   ├── smoke_test.py      # Smoke tests for package installation
+│   ├── test_cli.py        # CLI tests
+│   ├── test_integration.py # Integration tests
+│   ├── test_papermap.py   # PaperMap class tests
+│   ├── test_tile.py       # Tile tests
+│   ├── test_tile_server.py # TileServer tests
+│   └── test_utils.py      # Utility function tests
 ├── docs/                  # Sphinx documentation
 │   ├── conf.py            # Sphinx configuration
 │   ├── index.md           # Documentation index
 │   ├── api.md             # API reference
-│   ├── cli.md             # CLI reference
+│   ├── cli.md             # CLI reference (auto-generated with cog)
 │   ├── usage.md           # Usage guide
+│   ├── changelog.md       # Includes CHANGELOG.md
 │   └── _static/           # Static assets (example PDFs)
 ├── .github/workflows/     # GitHub Actions
+│   ├── ci.yml             # CI workflow (pre-commit hooks)
+│   ├── test.yml           # Test workflow (pytest across Python versions)
 │   └── publish.yml        # PyPI publishing workflow
 ├── pyproject.toml         # Project metadata and dependencies
 ├── .pre-commit-config.yaml # Pre-commit hooks configuration
+├── CHANGELOG.md           # Changelog (Keep a Changelog format)
+├── README.md              # Project README
+├── uv.lock                # uv lockfile
 ├── .editorconfig          # Editor configuration
-├── .gitignore             # Git ignore patterns
-└── README.md              # Project README
+└── .gitignore             # Git ignore patterns
 ```
+
+## Requirements for Every Change
+
+**IMPORTANT:** For every change made to the codebase, the following conditions MUST be met:
+
+1. **Tests:** Any missing tests are added to the test suite.
+1. **Tests Pass:** All tests must pass:
+   ```bash
+   uv run pytest
+   ```
+1. **Pre-commit Hooks Pass:** All checks in the pre-commit hooks must pass:
+   ```bash
+   uv run prek run --all-files
+   ```
+1. **API Documentation:** Any new modules are added to the API reference in `docs/api.md`.
+1. **CLI Documentation:** Any new CLI sub-commands are added to the CLI reference in `docs/cli.md`.
+1. **Changelog:** An entry (based on the Keep a Changelog format) is added to `CHANGELOG.md`.
+1. **README:** Any user-facing changes are reflected in the readme in `README.md`.
 
 ## Development Environment and Tools
 
 ### Build System
 
-- **Build Backend:** flit_core (>=3.2, \<4)
-- **Installation:** `pip install flit` or `pipx install flit`
-- **Local Development:** `flit install` (installs in editable mode)
+- **Build Backend:** uv_build (>=0.9.11, \<0.10.0)
+- **Package Manager:** uv
+- **Installation:** Install uv from https://docs.astral.sh/uv/
+
+### Setting Up Development Environment
+
+```bash
+# Clone repository
+git clone https://github.com/sgraaf/papermap.git
+cd papermap
+
+# Install uv (if not already installed)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Install dependencies (including dev dependencies)
+uv sync --dev
+
+# Install pre-commit hooks
+uv run prek install
+```
 
 ### Code Quality Tools
 
 #### Pre-commit Hooks (runs on every commit)
 
+The project uses `prek` (a pre-commit alternative) for running hooks. Hooks are defined in `.pre-commit-config.yaml`:
+
 1. **Basic Checks:** JSON, TOML, XML, YAML validation, EOF fixer, trailing whitespace
 1. **pyproject.toml validation:** Validates project configuration
 1. **GitHub workflows validation:** Validates .github/workflows/\*.yml
 1. **ReadTheDocs validation:** Validates .readthedocs.yaml
-1. **Ruff:** Python linter (replaces flake8, isort) with auto-fix
-1. **Black:** Code formatter (opinionated, no configuration)
-1. **mypy:** Static type checker with types-requests
+1. **Ruff:** Python linter and formatter (replaces flake8, isort, Black)
+   - `ruff-check`: Linting with auto-fix and unsafe fixes
+   - `ruff-format`: Code formatting
+1. **Type Checkers:**
+   - `mypy`: Static type checker
+   - `pyrefly`: Facebook's Python type checker
+   - `ty`: Extremely fast Python type checking
 1. **Codespell:** Spell checker for code and docs
-1. **Prettier:** Formatter for YAML, Markdown, JSON
+1. **Cog:** Auto-generates CLI documentation in `docs/cli.md`
+1. **mdformat:** Markdown formatter (with myst and ruff plugins)
+1. **Prettier:** YAML formatter
 
 #### Ruff Configuration (pyproject.toml)
 
 ```toml
-select = ["B", "C90", "E", "F", "I", "UP", "RUF100", "W"]
-ignore = ["E501"]  # Line length ignored (Black handles it)
-target-version = "py38"
+[tool.ruff.lint]
+select = ["ALL"]
+ignore = [
+    "COM812",  # missing-trailing-comma, handled by formatter
+    "D100",    # undocumented-public-module
+    "D102",    # undocumented-public-method
+    "D105",    # undocumented-magic-method
+    "D107",    # undocumented-public-init
+    "E501",    # line-too-long, handled by formatter
+    "PLC2401", # non-ascii-name (allows Greek letters in math code)
+]
+pydocstyle.convention = "google"
 ```
 
-- **B:** flake8-bugbear (likely bugs and design problems)
-- **C90:** mccabe (complexity)
-- **E/W:** pycodestyle errors and warnings
-- **F:** Pyflakes (Python errors)
-- **I:** isort (import sorting)
-- **UP:** pyupgrade (Python version upgrades)
-- **RUF100:** Ruff-specific rules
+#### Per-file Ignores
 
-#### Special Configurations
-
-- `__init__.py` files ignore F401 (unused imports) - allows re-exports
+- `__init__.py`: F401 (unused imports) - allows re-exports
+- `docs/conf.py`: INP001 (implicit namespace package)
+- `src/papermap/cli.py`: ANN401 (any-type)
+- `src/papermap/utils.py`: N806, PLR2004 (for mathematical code)
+- `tests/**/test_*.py`: D (docstrings), PLR2004, S101 (assert)
+- `tests/conftest.py`: D401 (non-imperative mood)
+- `tests/smoke_test.py`: PLR2004, S101
 
 ### Editor Configuration
 
@@ -178,36 +243,73 @@ Configuration for:
 - **Paper Sizes:** A-series (A0-A7), letter, legal
 - **Default Values:** Scale (25000), DPI (300), margins (10mm), grid size (1000m)
 
-## Development Workflows
+## Testing
 
-### Setting Up Development Environment
+### Test Structure
+
+Tests are located in the `tests/` directory and use pytest:
+
+- `conftest.py` - Shared fixtures (sample tiles, tile servers, coordinates)
+- `smoke_test.py` - Basic smoke tests for package installation
+- `test_utils.py` - Comprehensive unit tests for utility functions
+- `test_tile.py` - Tile dataclass tests
+- `test_tile_server.py` - TileServer tests
+- `test_papermap.py` - PaperMap class tests
+- `test_cli.py` - CLI tests
+- `test_integration.py` - Integration tests
+
+### Running Tests
 
 ```bash
-# Clone repository
-git clone https://github.com/sgraaf/papermap.git
-cd papermap
+# Run all tests
+uv run pytest
 
-# Install flit
-pip install flit
+# Run with coverage
+uv run pytest --cov
 
-# Install in development mode with all dependencies
-flit install --deps develop --symlink
+# Run specific test file
+uv run pytest tests/test_utils.py
 
-# Install pre-commit hooks
-pre-commit install
+# Run specific test class or function
+uv run pytest tests/test_utils.py::TestClip
+uv run pytest tests/test_utils.py::TestClip::test_clip_value_within_range
 ```
 
-### Code Style Conventions
+### Test Fixtures
 
-#### Python Style
+The `conftest.py` provides common fixtures:
 
-1. **Formatting:** Black (uncompromising, no configuration)
-1. **Line Length:** E501 ignored in Ruff (Black determines line breaks)
+- `sample_tile` - A basic Tile for testing
+- `sample_tile_with_image` - A Tile with an attached image
+- `sample_tile_server` - A basic TileServer
+- `sample_tile_server_with_mirrors` - TileServer with mirror support
+- `sample_tile_server_with_api_key` - TileServer requiring API key
+- `mock_tile_image` - A mock PIL Image
+- `mock_response` - A mock HTTP response for tile downloads
+- `coordinate_test_cases` - Well-known coordinate test cases (NYC, London, Tokyo, etc.)
+
+### Writing Tests
+
+Follow these conventions:
+
+1. Group related tests in classes (e.g., `class TestClip:`)
+1. Use descriptive test names (e.g., `test_clip_value_within_range`)
+1. Use pytest fixtures for common setup
+1. Use `@pytest.mark.parametrize` for testing multiple inputs
+1. Use `math.isclose()` for floating-point comparisons
+1. Test edge cases and boundary conditions
+
+## Code Style Conventions
+
+### Python Style
+
+1. **Formatting:** Ruff (via ruff-format, replacing Black)
+1. **Line Length:** E501 ignored (Ruff format determines line breaks)
 1. **Type Hints:** Fully typed (py.typed marker present)
 1. **Imports:** Sorted by Ruff (isort rules)
 1. **Docstrings:** Google-style docstrings with Args, Returns, Raises sections
 
-#### Example Docstring Format:
+### Example Docstring Format
 
 ```python
 def function_name(arg1: Type1, arg2: Type2) -> ReturnType:
@@ -227,7 +329,7 @@ def function_name(arg1: Type1, arg2: Type2) -> ReturnType:
     """
 ```
 
-#### Naming Conventions
+### Naming Conventions
 
 - **Classes:** PascalCase (e.g., `PaperMap`, `TileServer`)
 - **Functions/Methods:** snake_case (e.g., `render_grid`, `download_tiles`)
@@ -235,79 +337,113 @@ def function_name(arg1: Type1, arg2: Type2) -> ReturnType:
 - **Private:** Prefix with `_` (not commonly used in this codebase)
 - **Greek Letters:** Used in mathematical code (e.g., `φ` for phi/latitude, `λ` for lambda/longitude, `π` for pi)
 
-#### Import Order (enforced by Ruff)
+### Import Order (enforced by Ruff)
 
 1. Standard library imports
 1. Third-party imports (click, fpdf, PIL, requests)
 1. Local imports (relative imports from current package)
 
-### Testing Strategy
+## Documentation
 
-**Current State:** No test suite exists in the repository.
-
-**Observations:**
-
-- `pyproject.toml` includes a `[project.optional-dependencies]` section for tests with `pytest` and `cog`
-- No `tests/` directory or test files present
-- Pre-commit hooks validate code quality but don't run tests
-
-**Recommendations for Future Development:**
-
-- Add unit tests for utility functions (coordinate conversions, scale calculations)
-- Add integration tests for tile downloading (with mocked HTTP responses)
-- Add end-to-end tests for PDF generation
-- Set up CI/CD with pytest in GitHub Actions
-
-### Documentation
-
-#### Documentation System
+### Documentation System
 
 - **Tool:** Sphinx with MyST parser (Markdown support)
 - **Theme:** Furo
 - **Hosting:** ReadTheDocs (https://papermap.readthedocs.io/)
 - **Configuration:** `.readthedocs.yaml` and `docs/conf.py`
 
-#### Documentation Structure
+### Documentation Structure
 
 - `index.md` - Landing page
 - `installation.md` - Installation instructions
 - `usage.md` - User guide with examples
-- `cli.md` - CLI reference
+- `cli.md` - CLI reference (auto-generated via cog)
 - `api.md` - API reference
-- `changelog.md` - Version history
+- `changelog.md` - Includes CHANGELOG.md
 
-#### Extensions
+### CLI Documentation Auto-generation
+
+The CLI reference in `docs/cli.md` uses cog for auto-generation. When CLI commands change, the documentation is automatically updated by running:
+
+```bash
+uv run cog -r docs/cli.md
+```
+
+This is also checked in pre-commit hooks.
+
+### Adding New Modules to API Reference
+
+When adding a new module, add it to `docs/api.md`:
+
+```markdown
+## `papermap.new_module` Module
+
+\`\`\`{eval-rst}
+.. automodule:: papermap.new_module
+   :members:
+\`\`\`
+```
+
+### Extensions
 
 - `sphinx-copybutton` - Copy button for code blocks
 - `sphinxext-opengraph` - Open Graph metadata for social sharing
 - `myst-parser` - Markdown support
 
-### Release and Publishing
+## Changelog
 
-#### Publishing Workflow (GitHub Actions)
+### Format
 
-**Trigger:** On GitHub release creation
+The project uses the [Keep a Changelog](https://keepachangelog.com/) format in `CHANGELOG.md`. Categories include:
+
+- **Added** - New features
+- **Changed** - Changes in existing functionality
+- **Deprecated** - Soon-to-be removed features
+- **Removed** - Removed features
+- **Fixed** - Bug fixes
+- **Security** - Security vulnerability fixes
+
+### Example Entry
+
+```markdown
+## [Unreleased]
+
+### Added
+
+- New tile server support for XYZ Maps
+
+### Fixed
+
+- Fixed coordinate conversion issue at the date line
+```
+
+## Release and Publishing
+
+### Version Management
+
+- Version defined in `pyproject.toml` as `version = "YYYY.N.N"`
+- Uses CalVer (Calendar Versioning): YYYY.MINOR.PATCH
+- Example: `2026.1.0` = Year 2026, first minor release, no patches
+
+### Publishing Workflow (GitHub Actions)
+
+**Trigger:** On tag push matching `[0-9][0-9][0-9][0-9].[0-9]+.[0-9]+*`
 
 **Steps:**
 
 1. Checkout repository
-1. Set up Python 3.10
-1. Install Flit
-1. Install production dependencies
-1. Publish to PyPI using `PYPI_TOKEN` secret
+1. Install uv and Python 3.13
+1. Build with `uv build`
+1. Smoke test wheel installation
+1. Smoke test source distribution
+1. Publish to PyPI with `uv publish` (uses trusted publishing)
 
-#### Version Management
+### Release Checklist
 
-- Version defined in `src/papermap/__init__.py` as `__version__`
-- Flit reads version dynamically from module
-- Follow semantic versioning (MAJOR.MINOR.PATCH)
-
-#### Release Checklist
-
-1. Update `__version__` in `__init__.py`
-1. Update `docs/changelog.md`
+1. Update version in `pyproject.toml`
+1. Add entry to `CHANGELOG.md`
 1. Commit changes with message format: `:emoji: Description`
-1. Create GitHub release with tag `vX.Y.Z`
+1. Create and push tag: `git tag YYYY.N.N && git push origin YYYY.N.N`
 1. GitHub Actions automatically publishes to PyPI
 
 ### Commit Message Conventions
@@ -330,10 +466,16 @@ Example: `:sparkles: Add support for custom tile servers`
 
 ### When Making Changes
 
-1. **Always run pre-commit hooks:** Code must pass all checks before committing
+1. **Always run tests:**
 
    ```bash
-   pre-commit run --all-files
+   uv run pytest
+   ```
+
+1. **Always run pre-commit hooks:**
+
+   ```bash
+   uv run prek run --all-files
    ```
 
 1. **Type hints are mandatory:** All functions must have type annotations
@@ -344,14 +486,20 @@ Example: `:sparkles: Add support for custom tile servers`
 
 1. **Update documentation:** Changes to public API require documentation updates in `docs/`
 
+1. **Update changelog:** All changes require an entry in `CHANGELOG.md`
+
+1. **Add tests:** All new functionality requires corresponding tests
+
 ### Common Tasks
 
 #### Adding a New Tile Server
 
 1. Add entry to `TILE_SERVERS_MAP` in `defaults.py`
 1. Include attribution, URL template, zoom range, mirrors (if applicable)
-1. Update CLI choices will auto-populate
+1. CLI choices will auto-populate
+1. Add tests for the new tile server
 1. Test with and without API key (if applicable)
+1. Add changelog entry
 
 #### Modifying Coordinate Conversions
 
@@ -359,19 +507,30 @@ Example: `:sparkles: Add support for custom tile servers`
 1. Add citation in docstring
 1. Test with known coordinate pairs
 1. Verify edge cases (poles, dateline, UTM zone boundaries)
+1. Update existing tests if behavior changes
 
 #### Adding CLI Options
 
 1. Add to `common_parameters` decorator in `cli.py`
 1. Add corresponding parameter to `PaperMap.__init__()`
-1. Update `cli.md` documentation
+1. Run `uv run cog -r docs/cli.md` to update CLI documentation
+1. Add tests for the new option
 1. Test with various combinations
+1. Add changelog entry
+
+#### Adding a New Module
+
+1. Create the module in `src/papermap/`
+1. Add to `__init__.py` if it should be publicly exported
+1. Add to `docs/api.md` for API documentation
+1. Add corresponding test file in `tests/`
+1. Add changelog entry
 
 #### Updating Dependencies
 
 1. Modify `dependencies` in `pyproject.toml`
-1. Update `additional_dependencies` in `.pre-commit-config.yaml` if needed
-1. Test locally with `flit install`
+1. Run `uv sync` to update `uv.lock`
+1. Test locally with `uv run pytest`
 1. Update documentation if user-facing
 
 ### Code Patterns to Follow
@@ -433,7 +592,6 @@ self.pdf.cell(w=width, text=text, align="C", fill=True)
 
 ### Known Limitations
 
-1. **No Tests:** Test suite doesn't exist yet
 1. **No Error Recovery:** Tile download failures raise exceptions
 1. **Memory Usage:** Large maps load all tiles into memory
 1. **Single-page PDFs:** No multi-page map support
@@ -484,11 +642,12 @@ self.pdf.cell(w=width, text=text, align="C", fill=True)
 
 Common issues and fixes:
 
-1. **Ruff errors:** Run `ruff check --fix .` to auto-fix
-1. **Black formatting:** Run `black .` to reformat
-1. **mypy errors:** Add type hints or use `# type: ignore` comments (sparingly)
+1. **Ruff errors:** Run `uv run ruff check --fix .` to auto-fix
+1. **Ruff formatting:** Run `uv run ruff format .` to reformat
+1. **mypy/pyrefly/ty errors:** Add type hints or fix type issues
 1. **Trailing whitespace:** Editor issue, configure to trim on save
-1. **Codespell:** Real typos, fix them; false positives, add to `.codespellrc`
+1. **Codespell:** Real typos, fix them; false positives, add to ignore
+1. **Cog errors:** Run `uv run cog -r docs/cli.md` to regenerate
 
 ### Performance Considerations
 
@@ -504,35 +663,41 @@ ______________________________________________________________________
 **Install for development:**
 
 ```bash
-flit install --deps develop --symlink
-pre-commit install
+uv sync --dev
+uv run prek install
+```
+
+**Run tests:**
+
+```bash
+uv run pytest
 ```
 
 **Run code quality checks:**
 
 ```bash
-pre-commit run --all-files
+uv run prek run --all-files
 ```
 
 **Build documentation locally:**
 
 ```bash
 cd docs
-make html
+uv run sphinx-build -b html . _build/html
 ```
 
 **Test CLI locally:**
 
 ```bash
-python -m papermap latlon 40.7128 -74.0060 test.pdf
+uv run papermap latlon 40.7128 -74.0060 test.pdf
 ```
 
 **Publish new version:**
 
-1. Update `__version__` in `src/papermap/__init__.py`
-1. Update `docs/changelog.md`
+1. Update version in `pyproject.toml`
+1. Update `CHANGELOG.md`
 1. Commit and push
-1. Create GitHub release
+1. Create and push tag: `git tag YYYY.N.N && git push origin YYYY.N.N`
 1. GitHub Actions publishes to PyPI automatically
 
 ______________________________________________________________________


### PR DESCRIPTION
- Update version to 2026.1.0 (CalVer format)
- Update build system to uv_build (replacing flit)
- Update package manager to uv (replacing flit/pip)
- Document Python 3.10-3.14 support
- Add comprehensive test suite documentation
- Update pre-commit hooks documentation (prek, ruff, mypy, pyrefly, ty)
- Add "Requirements for Every Change" section with mandatory checks
- Document changelog format (Keep a Changelog)
- Update quick reference commands for uv
- Remove outdated information about missing tests