### PR TITLE
Add key and name properties to tile server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@
   - Tile server configurations moved to `tile_server.py`
   - Paper sizes and default values moved to `papermap.py`
   - Geographic constants and type aliases moved to `utils.py`
+- Enhanced `TileServer` dataclass with new properties:
+  - Added `key` property for tile server key (lowercase with dashes)
+  - Added `name` property for tile server display name
+  - Added `html_attribution` property for HTML-formatted attribution with hyperlinks
+  - Added `bounds` property for geographic bounds (optional)
+  - Renamed `mirrors` to `subdomains` for better clarity
+  - Renamed `mirrors_cycle` to `subdomains_cycle`
+  - Updated URL template placeholders: `{zoom}` → `{z}`, `{mirror}` → `{s}`, `{api_key}` → `{a}`
 
 ### Removed
 

--- a/src/papermap/papermap.py
+++ b/src/papermap/papermap.py
@@ -142,12 +142,14 @@ class PaperMap:
             msg = f"Invalid tile server. Please choose one of {', '.join(TILE_SERVERS)}"
             raise ValueError(msg)
 
-        # get the tile server mirrors
-        self.mirrors = self.tile_server.mirrors if self.tile_server.mirrors else []
+        # get the tile server subdomains
+        self.subdomains = (
+            self.tile_server.subdomains if self.tile_server.subdomains else []
+        )
 
         # check whether an API key is provided, if it is needed
         if (
-            "api_key" in get_string_formatting_arguments(self.tile_server.url_template)
+            "a" in get_string_formatting_arguments(self.tile_server.url_template)
             and self.api_key is None
         ):
             msg = f"No API key specified for {tile_server} tile server"

--- a/src/papermap/tile_server.py
+++ b/src/papermap/tile_server.py
@@ -13,28 +13,37 @@ class TileServer:
     """A tile server.
 
     Args:
+        key: The key of the tile server (fully lowercase with dashes instead of spaces).
+        name: The name of the tile server.
         attribution: The attribution of the tile server.
+        html_attribution: The HTML-version of the attribution (with hyperlinks).
         url_template: The URL template of the tile server. Allowed placeholders
-            are `{x}`, `{y}`, `{zoom}`, `{mirror}` and `{api_key}`, where `{x}`
+            are `{x}`, `{y}`, `{z}`, `{s}` and `{a}`, where `{x}`
             refers to the x coordinate of the tile, `{y}` refers to the y
-            coordinate of the tile, `{zoom}` to the zoom level, `{mirror}` to
-            the mirror (optional) and `{api_key}` to the API key (optional). See
+            coordinate of the tile, `{z}` to the zoom level, `{s}` to
+            the subdomain (optional) and `{a}` to the API key (optional). See
             `<https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Tile_servers>`_
             for more information.
         zoom_min: The minimum zoom level of the tile server.
         zoom_max: The maximum zoom level of the tile server.
-        mirrors: The mirrors of the tile server. Defaults to `None`.
+        bounds: The geographic bounds of the tile server (min_lon, min_lat, max_lon, max_lat).
+            Defaults to `None`.
+        subdomains: The subdomains of the tile server. Defaults to `None`.
     """
 
+    key: str
+    name: str
     attribution: str
+    html_attribution: str
     url_template: str
     zoom_min: int
     zoom_max: int
-    mirrors: list[str | int | None] | None = None
-    mirrors_cycle: cycle = field(init=False)
+    bounds: tuple[float, float, float, float] | None = None
+    subdomains: list[str | int | None] | None = None
+    subdomains_cycle: cycle = field(init=False)
 
     def __post_init__(self) -> None:
-        self.mirrors_cycle = cycle(self.mirrors or [None])
+        self.subdomains_cycle = cycle(self.subdomains or [None])
 
     def format_url_template(self, tile: Tile, api_key: str | None = None) -> str:
         """Format the URL template with the tile's coordinates and zoom level.
@@ -47,213 +56,303 @@ class TileServer:
             The formatted URL template.
         """
         return self.url_template.format(
-            mirror=next(self.mirrors_cycle),
+            s=next(self.subdomains_cycle),
             x=tile.x,
             y=tile.y,
-            zoom=tile.zoom,
-            api_key=api_key,
+            z=tile.zoom,
+            a=api_key,
         )
 
 
 TILE_SERVERS_MAP: dict[str, TileServer] = {
     "OpenStreetMap": TileServer(
+        key="openstreetmap",
+        name="OpenStreetMap",
         attribution="Map data: © OpenStreetMap contributors",
-        url_template="http://{mirror}.tile.osm.org/{zoom}/{x}/{y}.png",
-        mirrors=["a", "b", "c"],
+        html_attribution='Map data: © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>',
+        url_template="http://{s}.tile.osm.org/{z}/{x}/{y}.png",
+        subdomains=["a", "b", "c"],
         zoom_min=0,
         zoom_max=19,
     ),
     "OpenStreetMap Monochrome": TileServer(
+        key="openstreetmap-monochrome",
+        name="OpenStreetMap Monochrome",
         attribution="Map data: © OpenStreetMap contributors",
-        url_template="https://tiles.wmflabs.org/bw-mapnik/{zoom}/{x}/{y}.png",
+        html_attribution='Map data: © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>',
+        url_template="https://tiles.wmflabs.org/bw-mapnik/{z}/{x}/{y}.png",
         zoom_min=0,
         zoom_max=19,
     ),
     "OpenTopoMap": TileServer(
+        key="opentopomap",
+        name="OpenTopoMap",
         attribution="Map data: © OpenStreetMap contributors, SRTM. Map style: © OpenTopoMap (CC-BY-SA)",
-        url_template="https://{mirror}.tile.opentopomap.org/{zoom}/{x}/{y}.png",
-        mirrors=["a", "b", "c"],
+        html_attribution='Map data: © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>, <a href="https://www2.jpl.nasa.gov/srtm/">SRTM</a>. Map style: © <a href="https://opentopomap.org/">OpenTopoMap</a> (<a href="https://creativecommons.org/licenses/by-sa/3.0/">CC-BY-SA</a>)',
+        url_template="https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png",
+        subdomains=["a", "b", "c"],
         zoom_min=0,
         zoom_max=17,
     ),
     "Thunderforest Landscape": TileServer(
+        key="thunderforest-landscape",
+        name="Thunderforest Landscape",
         attribution="Map data: © OpenStreetMap contributors",
-        url_template="https://{mirror}.tile.thunderforest.com/landscape/{zoom}/{x}/{y}.png?apikey={api_key}",
-        mirrors=["a", "b", "c"],
+        html_attribution='Map data: © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>',
+        url_template="https://{s}.tile.thunderforest.com/landscape/{z}/{x}/{y}.png?apikey={a}",
+        subdomains=["a", "b", "c"],
         zoom_min=0,
         zoom_max=22,
     ),
     "Thunderforest Outdoors": TileServer(
+        key="thunderforest-outdoors",
+        name="Thunderforest Outdoors",
         attribution="Map data: © OpenStreetMap contributors",
-        url_template="https://{mirror}.tile.thunderforest.com/outdoors/{zoom}/{x}/{y}.png?apikey={api_key}",
-        mirrors=["a", "b", "c"],
+        html_attribution='Map data: © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>',
+        url_template="https://{s}.tile.thunderforest.com/outdoors/{z}/{x}/{y}.png?apikey={a}",
+        subdomains=["a", "b", "c"],
         zoom_min=0,
         zoom_max=22,
     ),
     "Thunderforest Transport": TileServer(
+        key="thunderforest-transport",
+        name="Thunderforest Transport",
         attribution="Map data: © OpenStreetMap contributors",
-        url_template="https://{mirror}.tile.thunderforest.com/transport/{zoom}/{x}/{y}.png?apikey={api_key}",
-        mirrors=["a", "b", "c"],
+        html_attribution='Map data: © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>',
+        url_template="https://{s}.tile.thunderforest.com/transport/{z}/{x}/{y}.png?apikey={a}",
+        subdomains=["a", "b", "c"],
         zoom_min=0,
         zoom_max=22,
     ),
     "Thunderforest OpenCycleMap": TileServer(
+        key="thunderforest-opencyclemap",
+        name="Thunderforest OpenCycleMap",
         attribution="Map data: © OpenStreetMap contributors",
-        url_template="https://{mirror}.tile.thunderforest.com/cycle/{zoom}/{x}/{y}.png?apikey={api_key}",
-        mirrors=["a", "b", "c"],
+        html_attribution='Map data: © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>',
+        url_template="https://{s}.tile.thunderforest.com/cycle/{z}/{x}/{y}.png?apikey={a}",
+        subdomains=["a", "b", "c"],
         zoom_min=0,
         zoom_max=22,
     ),
     "ESRI Standard": TileServer(
+        key="esri-standard",
+        name="ESRI Standard",
         attribution="Map data: © Esri",
-        url_template="https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{zoom}/{y}/{x}.png",
+        html_attribution='Map data: © <a href="https://www.esri.com/">Esri</a>',
+        url_template="https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}.png",
         zoom_min=0,
         zoom_max=17,
     ),
     "ESRI Satellite": TileServer(
+        key="esri-satellite",
+        name="ESRI Satellite",
         attribution="Map data: © Esri",
-        url_template="https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{zoom}/{y}/{x}.png",
+        html_attribution='Map data: © <a href="https://www.esri.com/">Esri</a>',
+        url_template="https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}.png",
         zoom_min=0,
         zoom_max=17,
     ),
     "ESRI Topo": TileServer(
+        key="esri-topo",
+        name="ESRI Topo",
         attribution="Map data: © Esri",
-        url_template="https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{zoom}/{y}/{x}.png",
+        html_attribution='Map data: © <a href="https://www.esri.com/">Esri</a>',
+        url_template="https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}.png",
         zoom_min=0,
         zoom_max=20,
     ),
     "ESRI Dark Gray": TileServer(
+        key="esri-dark-gray",
+        name="ESRI Dark Gray",
         attribution="Map data: © Esri",
-        url_template="https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{zoom}/{y}/{x}.png",
+        html_attribution='Map data: © <a href="https://www.esri.com/">Esri</a>',
+        url_template="https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}.png",
         zoom_min=0,
         zoom_max=16,
     ),
     "ESRI Light Gray": TileServer(
+        key="esri-light-gray",
+        name="ESRI Light Gray",
         attribution="Map data: © Esri",
-        url_template="https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{zoom}/{y}/{x}.png",
+        html_attribution='Map data: © <a href="https://www.esri.com/">Esri</a>',
+        url_template="https://services.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}.png",
         zoom_min=0,
         zoom_max=16,
     ),
     "ESRI Transportation": TileServer(
+        key="esri-transportation",
+        name="ESRI Transportation",
         attribution="Map data: © Esri",
-        url_template="https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Transportation/MapServer/tile/{zoom}/{y}/{x}.png",
+        html_attribution='Map data: © <a href="https://www.esri.com/">Esri</a>',
+        url_template="https://server.arcgisonline.com/ArcGIS/rest/services/Reference/World_Transportation/MapServer/tile/{z}/{y}/{x}.png",
         zoom_min=0,
         zoom_max=20,
     ),
     "Geofabrik Topo": TileServer(
+        key="geofabrik-topo",
+        name="Geofabrik Topo",
         attribution="Map data: © OpenStreetMap contributors",
-        url_template="http://{mirror}.tile.geofabrik.de/15173cf79060ee4a66573954f6017ab0/{zoom}/{x}/{y}.png",
-        mirrors=["a", "b", "c"],
+        html_attribution='Map data: © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>',
+        url_template="http://{s}.tile.geofabrik.de/15173cf79060ee4a66573954f6017ab0/{z}/{x}/{y}.png",
+        subdomains=["a", "b", "c"],
         zoom_min=0,
         zoom_max=19,
     ),
     "Google Maps": TileServer(
+        key="google-maps",
+        name="Google Maps",
         attribution="Map data: © Google",
-        url_template="http://mt{mirror}.google.com/vt/lyrs=m&hl=en&x={x}&y={y}&z={zoom}",
-        mirrors=[0, 1, 2, 3],
+        html_attribution='Map data: © <a href="https://www.google.com/maps">Google</a>',
+        url_template="http://mt{s}.google.com/vt/lyrs=m&hl=en&x={x}&y={y}&z={z}",
+        subdomains=[0, 1, 2, 3],
         zoom_min=0,
         zoom_max=19,
     ),
     "Google Maps Satellite": TileServer(
+        key="google-maps-satellite",
+        name="Google Maps Satellite",
         attribution="Map data: © Google",
-        url_template="http://mt{mirror}.google.com/vt/lyrs=s&hl=en&x={x}&y={y}&z={zoom}",
-        mirrors=[0, 1, 2, 3],
+        html_attribution='Map data: © <a href="https://www.google.com/maps">Google</a>',
+        url_template="http://mt{s}.google.com/vt/lyrs=s&hl=en&x={x}&y={y}&z={z}",
+        subdomains=[0, 1, 2, 3],
         zoom_min=0,
         zoom_max=19,
     ),
     "Google Maps Satellite Hybrid": TileServer(
+        key="google-maps-satellite-hybrid",
+        name="Google Maps Satellite Hybrid",
         attribution="Map data: © Google",
-        url_template="http://mt{mirror}.google.com/vt/lyrs=y&hl=en&x={x}&y={y}&z={zoom}",
-        mirrors=[0, 1, 2, 3],
+        html_attribution='Map data: © <a href="https://www.google.com/maps">Google</a>',
+        url_template="http://mt{s}.google.com/vt/lyrs=y&hl=en&x={x}&y={y}&z={z}",
+        subdomains=[0, 1, 2, 3],
         zoom_min=0,
         zoom_max=19,
     ),
     "Google Maps Terrain": TileServer(
+        key="google-maps-terrain",
+        name="Google Maps Terrain",
         attribution="Map data: © Google",
-        url_template="http://mt{mirror}.google.com/vt/lyrs=t&hl=en&x={x}&y={y}&z={zoom}",
-        mirrors=[0, 1, 2, 3],
+        html_attribution='Map data: © <a href="https://www.google.com/maps">Google</a>',
+        url_template="http://mt{s}.google.com/vt/lyrs=t&hl=en&x={x}&y={y}&z={z}",
+        subdomains=[0, 1, 2, 3],
         zoom_min=0,
         zoom_max=19,
     ),
     "Google Maps Terrain Hybrid": TileServer(
+        key="google-maps-terrain-hybrid",
+        name="Google Maps Terrain Hybrid",
         attribution="Map data: © Google",
-        url_template="http://mt{mirror}.google.com/vt/lyrs=p&hl=en&x={x}&y={y}&z={zoom}",
-        mirrors=[0, 1, 2, 3],
+        html_attribution='Map data: © <a href="https://www.google.com/maps">Google</a>',
+        url_template="http://mt{s}.google.com/vt/lyrs=p&hl=en&x={x}&y={y}&z={z}",
+        subdomains=[0, 1, 2, 3],
         zoom_min=0,
         zoom_max=19,
     ),
     "HERE Terrain": TileServer(
+        key="here-terrain",
+        name="HERE Terrain",
         attribution="Map data: © HERE",
-        url_template="https://{mirror}.aerial.maps.ls.hereapi.com/maptile/2.1/maptile/newest/terrain.day/{zoom}/{x}/{y}/256/png8?apiKey={api_key}",
-        mirrors=[1, 2, 3, 4],
+        html_attribution='Map data: © <a href="https://www.here.com/">HERE</a>',
+        url_template="https://{s}.aerial.maps.ls.hereapi.com/maptile/2.1/maptile/newest/terrain.day/{z}/{x}/{y}/256/png8?apiKey={a}",
+        subdomains=[1, 2, 3, 4],
         zoom_min=0,
         zoom_max=20,
     ),
     "HERE Satellite": TileServer(
+        key="here-satellite",
+        name="HERE Satellite",
         attribution="Map data: © HERE",
-        url_template="https://{mirror}.aerial.maps.ls.hereapi.com/maptile/2.1/maptile/newest/satellite.day/{zoom}/{x}/{y}/256/png8?apiKey={api_key}",
-        mirrors=[1, 2, 3, 4],
+        html_attribution='Map data: © <a href="https://www.here.com/">HERE</a>',
+        url_template="https://{s}.aerial.maps.ls.hereapi.com/maptile/2.1/maptile/newest/satellite.day/{z}/{x}/{y}/256/png8?apiKey={a}",
+        subdomains=[1, 2, 3, 4],
         zoom_min=0,
         zoom_max=20,
     ),
     "HERE Hybrid": TileServer(
+        key="here-hybrid",
+        name="HERE Hybrid",
         attribution="Map data: © HERE",
-        url_template="https://{mirror}.aerial.maps.ls.hereapi.com/maptile/2.1/maptile/newest/hybrid.day/{zoom}/{x}/{y}/256/png8?apiKey={api_key}",
-        mirrors=[1, 2, 3, 4],
+        html_attribution='Map data: © <a href="https://www.here.com/">HERE</a>',
+        url_template="https://{s}.aerial.maps.ls.hereapi.com/maptile/2.1/maptile/newest/hybrid.day/{z}/{x}/{y}/256/png8?apiKey={a}",
+        subdomains=[1, 2, 3, 4],
         zoom_min=0,
         zoom_max=20,
     ),
     "Mapy.cz": TileServer(
+        key="mapy-cz",
+        name="Mapy.cz",
         attribution="Map data: © OpenStreetMap contributors. Map style: © Sesznam.cz",
-        url_template="https://m{mirror}.mapserver.mapy.cz/turist-m/{zoom}-{x}-{y}.png",
-        mirrors=[1, 2, 3, 4],
+        html_attribution='Map data: © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>. Map style: © <a href="https://www.seznam.cz/">Sesznam.cz</a>',
+        url_template="https://m{s}.mapserver.mapy.cz/turist-m/{z}-{x}-{y}.png",
+        subdomains=[1, 2, 3, 4],
         zoom_min=0,
         zoom_max=19,
     ),
     "Stamen Terrain": TileServer(
+        key="stamen-terrain",
+        name="Stamen Terrain",
         attribution="Map data: © OpenStreetMap contributors. Map style: © Stamen Design (CC-BY-3.0)",
-        url_template="http://{mirror}.tile.stamen.com/terrain/{zoom}/{x}/{y}.png",
-        mirrors=["a", "b", "c"],
+        html_attribution='Map data: © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>. Map style: © <a href="http://stamen.com">Stamen Design</a> (<a href="https://creativecommons.org/licenses/by/3.0/">CC-BY-3.0</a>)',
+        url_template="http://{s}.tile.stamen.com/terrain/{z}/{x}/{y}.png",
+        subdomains=["a", "b", "c"],
         zoom_min=0,
         zoom_max=18,
     ),
     "Stamen Toner": TileServer(
+        key="stamen-toner",
+        name="Stamen Toner",
         attribution="Map data: © OpenStreetMap contributors. Map style: © Stamen Design (CC-BY-3.0)",
-        url_template="http://{mirror}.tile.stamen.com/toner/{zoom}/{x}/{y}.png",
-        mirrors=["a", "b", "c"],
+        html_attribution='Map data: © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>. Map style: © <a href="http://stamen.com">Stamen Design</a> (<a href="https://creativecommons.org/licenses/by/3.0/">CC-BY-3.0</a>)',
+        url_template="http://{s}.tile.stamen.com/toner/{z}/{x}/{y}.png",
+        subdomains=["a", "b", "c"],
         zoom_min=0,
         zoom_max=18,
     ),
     "Stamen Toner Lite": TileServer(
+        key="stamen-toner-lite",
+        name="Stamen Toner Lite",
         attribution="Map data: © OpenStreetMap contributors. Map style: © Stamen Design (CC-BY-3.0)",
-        url_template="http://{mirror}.tile.stamen.com/toner-lite/{zoom}/{x}/{y}.png",
-        mirrors=["a", "b", "c"],
+        html_attribution='Map data: © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>. Map style: © <a href="http://stamen.com">Stamen Design</a> (<a href="https://creativecommons.org/licenses/by/3.0/">CC-BY-3.0</a>)',
+        url_template="http://{s}.tile.stamen.com/toner-lite/{z}/{x}/{y}.png",
+        subdomains=["a", "b", "c"],
         zoom_min=0,
         zoom_max=18,
     ),
     "Komoot": TileServer(
+        key="komoot",
+        name="Komoot",
         attribution="Map data: © OpenStreetMap contributors",
-        url_template="http://{mirror}.tile.komoot.de/komoot-2/{zoom}/{x}/{y}.png",
-        mirrors=["a", "b", "c"],
+        html_attribution='Map data: © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>',
+        url_template="http://{s}.tile.komoot.de/komoot-2/{z}/{x}/{y}.png",
+        subdomains=["a", "b", "c"],
         zoom_min=0,
         zoom_max=19,
     ),
     "Wikimedia": TileServer(
+        key="wikimedia",
+        name="Wikimedia",
         attribution="Map data: © OpenStreetMap contributors",
-        url_template="https://maps.wikimedia.org/osm-intl/{zoom}/{x}/{y}.png",
+        html_attribution='Map data: © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>',
+        url_template="https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png",
         zoom_min=0,
         zoom_max=19,
     ),
     "Hike & Bike": TileServer(
+        key="hike-and-bike",
+        name="Hike & Bike",
         attribution="Map data: © OpenStreetMap contributors",
-        url_template="http://{mirror}.tiles.wmflabs.org/hikebike/{zoom}/{x}/{y}.png",
-        mirrors=["a", "b", "c"],
+        html_attribution='Map data: © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>',
+        url_template="http://{s}.tiles.wmflabs.org/hikebike/{z}/{x}/{y}.png",
+        subdomains=["a", "b", "c"],
         zoom_min=0,
         zoom_max=20,
     ),
     "AllTrails": TileServer(
+        key="alltrails",
+        name="AllTrails",
         attribution="Map data: © OpenStreetMap contributors",
-        url_template="http://alltrails.com/tiles/alltrailsOutdoors/{zoom}/{x}/{y}.png",
+        html_attribution='Map data: © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a>',
+        url_template="http://alltrails.com/tiles/alltrailsOutdoors/{z}/{x}/{y}.png",
         zoom_min=0,
         zoom_max=20,
     ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,8 +41,11 @@ def tile_image_content(tile_image: Image.Image) -> bytes:
 def tile_server() -> TileServer:
     """Return a sample tile server for testing."""
     return TileServer(
+        key="test-server",
+        name="Test Server",
         attribution="Test Attribution",
-        url_template="https://example.com/{zoom}/{x}/{y}.png",
+        html_attribution="Test Attribution",
+        url_template="https://example.com/{z}/{x}/{y}.png",
         zoom_min=0,
         zoom_max=19,
     )
@@ -50,13 +53,16 @@ def tile_server() -> TileServer:
 
 @pytest.fixture
 def tile_server_with_mirrors() -> TileServer:
-    """Return a sample tile server with mirrors for testing."""
+    """Return a sample tile server with subdomains for testing."""
     return TileServer(
+        key="test-server-with-subdomains",
+        name="Test Server With Subdomains",
         attribution="Test Attribution",
-        url_template="https://{mirror}.example.com/{zoom}/{x}/{y}.png",
+        html_attribution="Test Attribution",
+        url_template="https://{s}.example.com/{z}/{x}/{y}.png",
         zoom_min=0,
         zoom_max=19,
-        mirrors=["a", "b", "c"],
+        subdomains=["a", "b", "c"],
     )
 
 
@@ -64,8 +70,11 @@ def tile_server_with_mirrors() -> TileServer:
 def tile_server_with_api_key() -> TileServer:
     """Return a sample tile server requiring an API key for testing."""
     return TileServer(
+        key="test-server-with-api-key",
+        name="Test Server With API Key",
         attribution="Test Attribution",
-        url_template="https://example.com/{zoom}/{x}/{y}.png?api_key={api_key}",
+        html_attribution="Test Attribution",
+        url_template="https://example.com/{z}/{x}/{y}.png?api_key={a}",
         zoom_min=0,
         zoom_max=19,
     )

--- a/tests/test_tile_server.py
+++ b/tests/test_tile_server.py
@@ -9,46 +9,53 @@ class TestTileServerInit:
     """Tests for TileServer initialization."""
 
     def test_basic_init(self, tile_server: TileServer) -> None:
+        assert tile_server.key == "test-server"
+        assert tile_server.name == "Test Server"
         assert tile_server.attribution == "Test Attribution"
-        assert tile_server.url_template == "https://example.com/{zoom}/{x}/{y}.png"
+        assert tile_server.html_attribution == "Test Attribution"
+        assert tile_server.url_template == "https://example.com/{z}/{x}/{y}.png"
         assert tile_server.zoom_min == 0
         assert tile_server.zoom_max == 19
-        assert tile_server.mirrors is None
+        assert tile_server.bounds is None
+        assert tile_server.subdomains is None
 
-    def test_init_with_mirrors(self, tile_server_with_mirrors: TileServer) -> None:
-        assert tile_server_with_mirrors.mirrors == ["a", "b", "c"]
+    def test_init_with_subdomains(self, tile_server_with_mirrors: TileServer) -> None:
+        assert tile_server_with_mirrors.subdomains == ["a", "b", "c"]
 
-    def test_init_without_mirrors_creates_none_cycle(
+    def test_init_without_subdomains_creates_none_cycle(
         self, tile_server: TileServer
     ) -> None:
-        # Should cycle through [None] when no mirrors
-        result = next(tile_server.mirrors_cycle)
+        # Should cycle through [None] when no subdomains
+        result = next(tile_server.subdomains_cycle)
         assert result is None
 
-    def test_init_with_mirrors_creates_cycle(
+    def test_init_with_subdomains_creates_cycle(
         self, tile_server_with_mirrors: TileServer
     ) -> None:
-        # Should cycle through mirrors
-        result1 = next(tile_server_with_mirrors.mirrors_cycle)
-        result2 = next(tile_server_with_mirrors.mirrors_cycle)
-        result3 = next(tile_server_with_mirrors.mirrors_cycle)
-        result4 = next(tile_server_with_mirrors.mirrors_cycle)
+        # Should cycle through subdomains
+        result1 = next(tile_server_with_mirrors.subdomains_cycle)
+        result2 = next(tile_server_with_mirrors.subdomains_cycle)
+        result3 = next(tile_server_with_mirrors.subdomains_cycle)
+        result4 = next(tile_server_with_mirrors.subdomains_cycle)
 
         assert result1 == "a"
         assert result2 == "b"
         assert result3 == "c"
         assert result4 == "a"  # Cycles back
 
-    def test_init_with_integer_mirrors(self) -> None:
+    def test_init_with_integer_subdomains(self) -> None:
         ts = TileServer(
+            key="test-int-subdomains",
+            name="Test Integer Subdomains",
             attribution="Test",
-            url_template="https://mt{mirror}.example.com/{zoom}/{x}/{y}.png",
+            html_attribution="Test",
+            url_template="https://mt{s}.example.com/{z}/{x}/{y}.png",
             zoom_min=0,
             zoom_max=19,
-            mirrors=[0, 1, 2, 3],
+            subdomains=[0, 1, 2, 3],
         )
-        mirrors = [next(ts.mirrors_cycle) for _ in range(8)]
-        assert mirrors == [0, 1, 2, 3, 0, 1, 2, 3]
+        subdomains = [next(ts.subdomains_cycle) for _ in range(8)]
+        assert subdomains == [0, 1, 2, 3, 0, 1, 2, 3]
 
 
 class TestTileServerFormatUrlTemplate:
@@ -59,10 +66,10 @@ class TestTileServerFormatUrlTemplate:
         # sample_tile has x=123, y=456, zoom=10
         assert result == "https://example.com/10/123/456.png"
 
-    def test_formatting_with_mirrors_cycles(
+    def test_formatting_with_subdomains_cycles(
         self, tile_server_with_mirrors: TileServer, tile: Tile
     ) -> None:
-        # Each call should use next mirror in cycle
+        # Each call should use next subdomain in cycle
         result1 = tile_server_with_mirrors.format_url_template(tile)
         result2 = tile_server_with_mirrors.format_url_template(tile)
         result3 = tile_server_with_mirrors.format_url_template(tile)
@@ -87,62 +94,74 @@ class TestTileServerFormatUrlTemplate:
 
     def test_formatting_osm_style_template(self, tile: Tile) -> None:
         ts = TileServer(
+            key="osm-test",
+            name="OSM Test",
             attribution="OSM",
-            url_template="http://{mirror}.tile.osm.org/{zoom}/{x}/{y}.png",
+            html_attribution="OSM",
+            url_template="http://{s}.tile.osm.org/{z}/{x}/{y}.png",
             zoom_min=0,
             zoom_max=19,
-            mirrors=["a", "b", "c"],
+            subdomains=["a", "b", "c"],
         )
         result = ts.format_url_template(tile)
         assert result == "http://a.tile.osm.org/10/123/456.png"
 
     def test_formatting_google_style_template(self, tile: Tile) -> None:
         ts = TileServer(
+            key="google-test",
+            name="Google Test",
             attribution="Google",
-            url_template="http://mt{mirror}.google.com/vt/lyrs=m&x={x}&y={y}&z={zoom}",
+            html_attribution="Google",
+            url_template="http://mt{s}.google.com/vt/lyrs=m&x={x}&y={y}&z={z}",
             zoom_min=0,
             zoom_max=19,
-            mirrors=[0, 1, 2, 3],
+            subdomains=[0, 1, 2, 3],
         )
         result = ts.format_url_template(tile)
         assert result == "http://mt0.google.com/vt/lyrs=m&x=123&y=456&z=10"
 
 
-class TestTileServerMirrorsCycle:
-    """Tests for TileServer mirrors cycling behavior."""
+class TestTileServerSubdomainsCycle:
+    """Tests for TileServer subdomains cycling behavior."""
 
-    def test_mirrors_cycle_is_infinite(
+    def test_subdomains_cycle_is_infinite(
         self, tile_server_with_mirrors: TileServer
     ) -> None:
         # Should be able to get many values without error
         for _ in range(100):
-            next(tile_server_with_mirrors.mirrors_cycle)
+            next(tile_server_with_mirrors.subdomains_cycle)
 
-    def test_single_mirror_cycles(self) -> None:
+    def test_single_subdomain_cycles(self) -> None:
         ts = TileServer(
+            key="single-subdomain",
+            name="Single Subdomain",
             attribution="Test",
-            url_template="https://{mirror}.example.com/{zoom}/{x}/{y}.png",
+            html_attribution="Test",
+            url_template="https://{s}.example.com/{z}/{x}/{y}.png",
             zoom_min=0,
             zoom_max=19,
-            mirrors=["only"],
+            subdomains=["only"],
         )
-        result1 = next(ts.mirrors_cycle)
-        result2 = next(ts.mirrors_cycle)
-        result3 = next(ts.mirrors_cycle)
+        result1 = next(ts.subdomains_cycle)
+        result2 = next(ts.subdomains_cycle)
+        result3 = next(ts.subdomains_cycle)
         assert result1 == result2 == result3 == "only"
 
-    def test_empty_mirrors_treated_as_none(self) -> None:
+    def test_empty_subdomains_treated_as_none(self) -> None:
         ts = TileServer(
+            key="empty-subdomains",
+            name="Empty Subdomains",
             attribution="Test",
-            url_template="https://example.com/{zoom}/{x}/{y}.png",
+            html_attribution="Test",
+            url_template="https://example.com/{z}/{x}/{y}.png",
             zoom_min=0,
             zoom_max=19,
-            mirrors=[],
+            subdomains=[],
         )
         # Empty list should result in [None] cycle behavior
-        # Actually looking at the code: cycle(self.mirrors or [None])
+        # Actually looking at the code: cycle(self.subdomains or [None])
         # Empty list is falsy, so should become [None]
-        result = next(ts.mirrors_cycle)
+        result = next(ts.subdomains_cycle)
         assert result is None
 
 
@@ -151,33 +170,49 @@ class TestTileServerEquality:
 
     def test_equal_tile_servers(self) -> None:
         ts1 = TileServer(
+            key="test",
+            name="Test",
             attribution="Test",
-            url_template="https://example.com/{zoom}/{x}/{y}.png",
+            html_attribution="Test",
+            url_template="https://example.com/{z}/{x}/{y}.png",
             zoom_min=0,
             zoom_max=19,
         )
         ts2 = TileServer(
+            key="test",
+            name="Test",
             attribution="Test",
-            url_template="https://example.com/{zoom}/{x}/{y}.png",
+            html_attribution="Test",
+            url_template="https://example.com/{z}/{x}/{y}.png",
             zoom_min=0,
             zoom_max=19,
         )
+        assert ts1.key == ts2.key
+        assert ts1.name == ts2.name
         assert ts1.attribution == ts2.attribution
+        assert ts1.html_attribution == ts2.html_attribution
         assert ts1.url_template == ts2.url_template
         assert ts1.zoom_min == ts2.zoom_min
         assert ts1.zoom_max == ts2.zoom_max
-        assert ts1.mirrors == ts2.mirrors
+        assert ts1.bounds == ts2.bounds
+        assert ts1.subdomains == ts2.subdomains
 
     def test_different_attribution(self) -> None:
         ts1 = TileServer(
+            key="test1",
+            name="Test1",
             attribution="Test1",
-            url_template="https://example.com/{zoom}/{x}/{y}.png",
+            html_attribution="Test1",
+            url_template="https://example.com/{z}/{x}/{y}.png",
             zoom_min=0,
             zoom_max=19,
         )
         ts2 = TileServer(
+            key="test2",
+            name="Test2",
             attribution="Test2",
-            url_template="https://example.com/{zoom}/{x}/{y}.png",
+            html_attribution="Test2",
+            url_template="https://example.com/{z}/{x}/{y}.png",
             zoom_min=0,
             zoom_max=19,
         )
@@ -185,14 +220,20 @@ class TestTileServerEquality:
 
     def test_different_zoom_range(self) -> None:
         ts1 = TileServer(
+            key="test",
+            name="Test",
             attribution="Test",
-            url_template="https://example.com/{zoom}/{x}/{y}.png",
+            html_attribution="Test",
+            url_template="https://example.com/{z}/{x}/{y}.png",
             zoom_min=0,
             zoom_max=19,
         )
         ts2 = TileServer(
+            key="test",
+            name="Test",
             attribution="Test",
-            url_template="https://example.com/{zoom}/{x}/{y}.png",
+            html_attribution="Test",
+            url_template="https://example.com/{z}/{x}/{y}.png",
             zoom_min=0,
             zoom_max=17,
         )
@@ -205,8 +246,11 @@ class TestTileServerValidation:
     def test_zoom_min_less_than_max(self) -> None:
         # This should work
         ts = TileServer(
+            key="test",
+            name="Test",
             attribution="Test",
-            url_template="https://example.com/{zoom}/{x}/{y}.png",
+            html_attribution="Test",
+            url_template="https://example.com/{z}/{x}/{y}.png",
             zoom_min=0,
             zoom_max=19,
         )
@@ -215,8 +259,11 @@ class TestTileServerValidation:
     def test_zoom_min_equals_max(self) -> None:
         # Edge case: single zoom level
         ts = TileServer(
+            key="test",
+            name="Test",
             attribution="Test",
-            url_template="https://example.com/{zoom}/{x}/{y}.png",
+            html_attribution="Test",
+            url_template="https://example.com/{z}/{x}/{y}.png",
             zoom_min=10,
             zoom_max=10,
         )
@@ -228,33 +275,42 @@ class TestRealTileServers:
 
     def test_openstreetmap_config(self) -> None:
         osm = TILE_SERVERS_MAP["OpenStreetMap"]
+        assert osm.key == "openstreetmap"
+        assert osm.name == "OpenStreetMap"
         assert osm.zoom_min == 0
         assert osm.zoom_max == 19
-        assert osm.mirrors == ["a", "b", "c"]
+        assert osm.subdomains == ["a", "b", "c"]
         assert "OpenStreetMap" in osm.attribution
 
     def test_google_maps_config(self) -> None:
         google = TILE_SERVERS_MAP["Google Maps"]
+        assert google.key == "google-maps"
+        assert google.name == "Google Maps"
         assert google.zoom_min == 0
         assert google.zoom_max == 19
-        assert google.mirrors == [0, 1, 2, 3]
+        assert google.subdomains == [0, 1, 2, 3]
         assert "Google" in google.attribution
 
     def test_esri_config(self) -> None:
         esri = TILE_SERVERS_MAP["ESRI Standard"]
+        assert esri.key == "esri-standard"
+        assert esri.name == "ESRI Standard"
         assert esri.zoom_min == 0
         assert esri.zoom_max == 17
-        assert esri.mirrors is None
+        assert esri.subdomains is None
         assert "Esri" in esri.attribution
 
     def test_thunderforest_requires_api_key(self) -> None:
         tf = TILE_SERVERS_MAP["Thunderforest Landscape"]
         args = get_string_formatting_arguments(tf.url_template)
-        assert "api_key" in args
+        assert "a" in args
 
     def test_all_tile_servers_have_required_fields(self) -> None:
         for name, ts in TILE_SERVERS_MAP.items():
+            assert ts.key, f"{name} missing key"
+            assert ts.name, f"{name} missing name"
             assert ts.attribution, f"{name} missing attribution"
+            assert ts.html_attribution, f"{name} missing html_attribution"
             assert ts.url_template, f"{name} missing url_template"
             assert ts.zoom_min >= 0, f"{name} has invalid zoom_min"
             assert ts.zoom_max >= ts.zoom_min, f"{name} has invalid zoom range"


### PR DESCRIPTION
- Add key, name, html_attribution, and bounds properties to TileServer
- Rename mirrors to subdomains for better clarity
- Update URL template placeholders: {zoom} → {z}, {mirror} → {s}, {api_key} → {a}
- Update all tests to reflect new TileServer structure
- Update CHANGELOG.md with new features